### PR TITLE
alternate location support for ios

### DIFF
--- a/src/epub-reader.ios.ts
+++ b/src/epub-reader.ios.ts
@@ -14,7 +14,7 @@ export class EpubReader {
         return version;
     }
     open(fileName: string) {
-        let bookPath = NSBundle.mainBundle.pathForResourceOfType(fileName, 'epub');
+        let bookPath = NSBundle.mainBundle.pathForResourceOfType(fileName, 'epub') || fileName;
         FolioReader.presentReaderWithParentViewControllerWithEpubPathAndConfigShouldRemoveEpubAnimated(
             topmost().currentPage.ios,
             bookPath,


### PR DESCRIPTION
for a dowloaded epub, it wont be in the main bundle, but instead be in a Data Container, fromt hat container you can fetch the path, so can we make this more on par with android version either pass file name in bundle OR use the name as an abolute path

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

